### PR TITLE
Fix for "MalformedInput - Start of list found where not expected

### DIFF
--- a/src/AmazonCore.php
+++ b/src/AmazonCore.php
@@ -620,6 +620,7 @@ abstract class AmazonCore
 
         unset($this->options['Signature']);
         $this->options['Timestamp'] = $this->genTime();
+        uksort($this->options, 'strcmp');
         $this->options['Signature'] = $this->_signParameters($this->options, $secretKey);
 
         return $this->_getParametersAsString($this->options);
@@ -896,7 +897,6 @@ abstract class AmazonCore
         $uriencoded = implode('/', array_map([$this, '_urlencode'], explode('/', $uri)));
         $data .= $uriencoded;
         $data .= "\n";
-        uksort($parameters, 'strcmp');
         $data .= $this->_getParametersAsString($parameters);
 
         return $data;

--- a/src/AmazonOrderList.php
+++ b/src/AmazonOrderList.php
@@ -58,6 +58,7 @@ class AmazonOrderList extends AmazonOrderCore implements Iterator
 
         $config_options = $this->getOptions();
         $this->options['MarketplaceId.Id.1'] = $config_options['MarketplaceId'];
+        unset($this->options['MarketplaceId']);
 
         if (isset($THROTTLE_LIMIT_ORDERLIST)) {
             $this->throttleLimit = $THROTTLE_LIMIT_ORDERLIST;


### PR DESCRIPTION
These simple changes solved the "MalformedInput" issue I experienced with `5.0.1`

Unless there is a reason the query parameters should not be sorted for both pre-signature and signature use, I don't see any breaking change coming from the `AmazonCore.php` alteration.

Perhaps a `5.0.2` tag could be added.